### PR TITLE
Update package_manager.rst for linuxmint

### DIFF
--- a/reference/conanfile/tools/system/package_manager.rst
+++ b/reference/conanfile/tools/system/package_manager.rst
@@ -36,7 +36,7 @@ System name. In the example above, if we are running on Ubuntu Linux, Conan will
 all the calls except for the ``Apt()`` one and will only try to install the packages using the
 ``apt-get`` tool. Conan uses the following mapping by default:
 
-* *Apt* for **Linux** with distribution names: *ubuntu*, *debian* or *raspbian*
+* *Apt* for **Linux** with distribution names: *ubuntu*, *debian*, *raspbian* or *linuxmint*
 * *Yum* for **Linux** with distribution names: *pidora*, *scientific*, *xenserver*, *amazon*, *oracle*, *amzn*, *almalinux* or *rocky*
 * *Dnf* for **Linux** with distribution names: *fedora*, *rhel*, *centos*, *mageia*
 * *Brew* for **macOS**
@@ -114,7 +114,7 @@ conan.tools.system.package_manager.Apt
 Available since: `1.45.0 <https://github.com/conan-io/conan/releases/tag/1.45.0>`_
 
 Will invoke the *apt-get* command. Enabled by default for **Linux** with distribution
-names: *ubuntu* and *debian*.
+names: *ubuntu*, *debian*, *raspbian* and *linuxmint*.
 
 Constructor
 +++++++++++


### PR DESCRIPTION
Mentions the apt-get package manager is used by default on Linux Mint as well.
Supports the PR here: https://github.com/conan-io/conan/pull/15026